### PR TITLE
Catalogue API: Update README with service port numbers and add initial Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # ProdTrack. Backend
 
 Backend repo of the ProdTrack project.
+
+## Ports
+
+The port numbers for microservices are as follows:
+
+| Microservice | Local Env         | Docker Env        | Docker Inside   |
+| ------------ | ----------------- | ----------------- | --------------- |
+| Catalogue    | `15000` / `15050` | `16000` / `16060` | `8080` / `8081` |
+
+ASP.NET Core ports are listed as HTTP / HTTPS for running application.
+
+In local development, for example, the catalog microservice will expose services on port `15000` for HTTP and `15050` for HTTPS. Once local development is complete, we'll shift to a Docker environment. In Docker, the HTTP service will be exposed on port `16000`, and HTTPS on port `16060`.
+
+This setup remains consistent across microservices as these port numbers are specified in the Dockerfile's environment variables for any ASP.NET application. Internally, Docker will use ports `80`, `8080`, and `8081` for HTTP and HTTPS, while externally, we expose the services on ports starting from `16000` for `access`.

--- a/postman/ProdTrack.postman_collection.json
+++ b/postman/ProdTrack.postman_collection.json
@@ -1,0 +1,41 @@
+{
+	"info": {
+		"_postman_id": "41edf411-0886-48e8-a33f-4cc115dcca70",
+		"name": "ProdTrack",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "15705090"
+	},
+	"item": [
+		{
+			"name": "1 Catalogue",
+			"item": [
+				{
+					"name": "Create Product",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"Name\": \"Generic Product\",\r\n    \"Category\": [\"Clothes\", \"Accessories\"],\r\n    \"Description\": \"Description of a generic product.\",\r\n    \"ImageFile\": \"Generic Product Image File\",\r\n    \"Price\": 199.99\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{catalogue_url}}/products",
+							"host": [
+								"{{catalogue_url}}"
+							],
+							"path": [
+								"products"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
I updated the project README file with currently available service port numbers and added an initial Postman collection which defines a `POST /products` request.